### PR TITLE
Adds support for Linux/Windows valet ports

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,9 +62,23 @@ class LaravelMixValet {
     }
 
     loadCert(ext) {
+        let dir;
+
+        if (process.platform === 'linux') {
+            dir = '.valet';
+        } 
+        
+        if (['darwin', 'win32'].includes(process.platform)) {
+            dir = '.config/valet';
+        }
+
+        if (!dir) {
+            throw new Error(`Unsupported platform: ${process.platform}`);
+        }
+
         const cert = path.resolve(
             process.env.HOME,
-            `.config/valet/Certificates/${this.config.host}.${ext}`
+            `${dir}/Certificates/${this.config.host}.${ext}`
         );
 
         if (!fs.existsSync(cert)) {


### PR DESCRIPTION
Hey @andreiio 👋

I've been using this package successfully for about a year or so on macOS, then recently needed to run a development environment on a Linux OS.

I found a port of Valet for Linux here: https://cpriego.github.io/valet-linux/, which uses a different directory for configuration.

This PR adds code to check `process.platform` and inject the correct directory for macOS, Linux, and [Windows](https://github.com/cretueusebiu/valet-windows).